### PR TITLE
bugfix: host parameter in Client.__init__ works without address

### DIFF
--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -114,7 +114,7 @@ class Client:
     """
     def __init__(
         self,
-        address=DEFAULT_HOST,
+        address=None,
         host=DEFAULT_HOST,
         port=DEFAULT_PORT,
         protocol=DEFAULT_PROTOCOL,


### PR DESCRIPTION
Per the log warnings in Client, address is a deprecated field and host should be used instead.
However, specifying host without also specifying address results in host being overwritten
with the default host.