### PR TITLE
fix: failed to add url which is http url but not endwith 'torrent'

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -78,6 +78,13 @@ def test_real_add_torrent_http(tr_client: Client):
     assert len(tr_client.get_torrents()) == 1, 'transmission should has at least 1 task'
 
 
+def test_real_add_torrent_not_endswith_torrent(tr_client: Client):
+    # The shorten url is ref to
+    # "https://github.com/Trim21/transmission-rpc/raw/master/tests/fixtures/iso.torrent"
+    tr_client.add_torrent('https://git.io/JJUVt')
+    assert len(tr_client.get_torrents()) == 1, 'transmission should has at least 1 task'
+
+
 def test_real_stop(tr_client: Client, fake_hash_factory):
     info_hash = fake_hash_factory()
     url = hash_to_magnet(info_hash)

--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -1,3 +1,4 @@
+# Copyright (c) 2020 littleya <me@littleya.com>
 # Copyright (c) 2018-2020 Trim21 <i@trim21.me>
 # Copyright (c) 2008-2014 Erik Svensson <erik.public@gmail.com>
 # Licensed under the MIT license.
@@ -332,7 +333,7 @@ class Client:
                     might_be_base64 = False
                     try:
                         # check if this is base64 data
-                        base64.b64decode(torrent.encode('utf-8'))
+                        base64.b64decode(torrent.encode('utf-8'), validate=True)
                         might_be_base64 = True
                     except Exception:
                         pass


### PR DESCRIPTION
In python3, base64.bdecode will return alternative alphabet if the
string can't be decoded and validate is Fasle, this will cause failed
to add torrent.

The patch set validate as True, if validate failed, client will handle
the string as url.

ref: https://docs.python.org/3/library/base64.html#base64.b64encode


close # <!-- delete this if it's related to a issue  -->
