### PR TITLE
fix: make sure `id` is always in `arguments`

### DIFF
--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -541,7 +541,9 @@ class Client:
 
         Returns a list of Torrent object.
         """
-        if not arguments:
+        if arguments:
+            arguments = list(set(arguments) | {"id"})
+        else:
             arguments = self.torrent_get_arguments
         return list(
             self._request(


### PR DESCRIPTION
close #94