### PR TITLE
chore: add local timezone when converting timestamp

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -796,7 +796,7 @@ docs = ["sphinx", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "dacbbec97790cd605b4dce385383eb8cb74436e3fe22931e599a0a9bcdd0c10b"
+content-hash = "9f524947f2c68489399f081b56eb598fcad653a63ed25c4c809cab3faa1bc8bb"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ pylint = "==2.8.3"
 sphinx-autobuild = "2021.3.14"
 # stubs
 types-requests = "2.25.0"
+pytz = "^2021.1"
 
 [tool.isort]
 default_section = 'THIRDPARTY'

--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -1,9 +1,11 @@
+# Copyright (c) 2020-2021 Trim21 <i@trim21.me>
 # 2008-12, Erik Svensson <erik.public@gmail.com>
-# Copyright (c) 2020 Trim21 <i@trim21.me>
 # Licensed under the MIT license.
 import time
+import calendar
 import datetime
 
+import pytz
 import pytest
 
 import transmission_rpc
@@ -56,10 +58,10 @@ def test_attributes():
         "uploadRatio": 0.5,
         "eta": 3600,
         "percentDone": 0.5,
-        "activityDate": time.mktime((2008, 12, 11, 11, 15, 30, 0, 0, -1)),
-        "addedDate": time.mktime((2008, 12, 11, 8, 5, 10, 0, 0, -1)),
-        "startDate": time.mktime((2008, 12, 11, 9, 10, 5, 0, 0, -1)),
-        "doneDate": time.mktime((2008, 12, 11, 10, 0, 15, 0, 0, -1)),
+        "activityDate": calendar.timegm((2008, 12, 11, 11, 15, 30, 0, 0, -1)),
+        "addedDate": calendar.timegm((2008, 12, 11, 8, 5, 10, 0, 0, -1)),
+        "startDate": calendar.timegm((2008, 12, 11, 9, 10, 5, 0, 0, -1)),
+        "doneDate": calendar.timegm((2008, 12, 11, 10, 0, 15, 0, 0, -1)),
     }
 
     torrent = transmission_rpc.Torrent(None, data)
@@ -69,10 +71,18 @@ def test_attributes():
     assert torrent.progress == 50.0
     assert torrent.ratio == 0.5
     assert torrent.eta == datetime.timedelta(seconds=3600)
-    assert torrent.date_active == datetime.datetime(2008, 12, 11, 11, 15, 30)
-    assert torrent.date_added == datetime.datetime(2008, 12, 11, 8, 5, 10)
-    assert torrent.date_started == datetime.datetime(2008, 12, 11, 9, 10, 5)
-    assert torrent.date_done == datetime.datetime(2008, 12, 11, 10, 0, 15)
+    assert torrent.date_active == datetime.datetime(
+        2008, 12, 11, 11, 15, 30, tzinfo=pytz.utc
+    )
+    assert torrent.date_added == datetime.datetime(
+        2008, 12, 11, 8, 5, 10, tzinfo=pytz.utc
+    )
+    assert torrent.date_started == datetime.datetime(
+        2008, 12, 11, 9, 10, 5, tzinfo=pytz.utc
+    )
+    assert torrent.date_done == datetime.datetime(
+        2008, 12, 11, 10, 0, 15, tzinfo=pytz.utc
+    )
 
     assert torrent.format_eta() == transmission_rpc.utils.format_timedelta(torrent.eta)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -67,18 +67,6 @@ def test_format_timedelta(delta, expected):
 
 
 @pytest.mark.parametrize(
-    ("timestamp", "expected"),
-    [
-        (0, "-"),
-        (1, "1970-01-01 00:00:01"),
-        (1129135532, "2005-10-12 16:45:32"),
-    ],
-)
-def test_format_timestamp(timestamp, expected):
-    assert utils.format_timestamp(timestamp, utc=True) == expected
-
-
-@pytest.mark.parametrize(
     ("value", "expected"),
     [
         (0, 0),

--- a/transmission_rpc/torrent.py
+++ b/transmission_rpc/torrent.py
@@ -313,7 +313,9 @@ class Torrent:
 
         :rtype: datetime.timedelta
         """
-        return datetime.datetime.fromtimestamp(self._fields["activityDate"].value)
+        return datetime.datetime.fromtimestamp(
+            self._fields["activityDate"].value
+        ).astimezone()
 
     @property
     def date_added(self) -> datetime.datetime:
@@ -322,7 +324,9 @@ class Torrent:
 
         :rtype: datetime.timedelta
         """
-        return datetime.datetime.fromtimestamp(self._fields["addedDate"].value)
+        return datetime.datetime.fromtimestamp(
+            self._fields["addedDate"].value
+        ).astimezone()
 
     @property
     def date_started(self) -> datetime.datetime:
@@ -331,7 +335,9 @@ class Torrent:
 
         :rtype: datetime.timedelta
         """
-        return datetime.datetime.fromtimestamp(self._fields["startDate"].value)
+        return datetime.datetime.fromtimestamp(
+            self._fields["startDate"].value
+        ).astimezone()
 
     @property
     def date_done(self) -> Optional[datetime.datetime]:
@@ -341,7 +347,7 @@ class Torrent:
         # so if doneDate is zero return None
         if done_date == 0:
             return None
-        return datetime.datetime.fromtimestamp(done_date)
+        return datetime.datetime.fromtimestamp(done_date).astimezone()
 
     def format_eta(self) -> str:
         """

--- a/transmission_rpc/utils.py
+++ b/transmission_rpc/utils.py
@@ -39,19 +39,6 @@ def format_timedelta(delta: datetime.timedelta) -> str:
     return "%d %02d:%02d:%02d" % (delta.days, hours, minutes, seconds)
 
 
-def format_timestamp(timestamp: int, utc: bool = False) -> str:
-    """
-    Format unix timestamp into ISO date format.
-    """
-    if timestamp > 0:
-        if utc:
-            dt_timestamp = datetime.datetime.utcfromtimestamp(timestamp)
-        else:
-            dt_timestamp = datetime.datetime.fromtimestamp(timestamp)
-        return dt_timestamp.isoformat(" ")
-    return "-"
-
-
 def rpc_bool(arg: Any) -> int:
     """
     Convert between Python boolean and Transmission RPC boolean.


### PR DESCRIPTION
`Torrent.date_active`, `Torrent.data_added`, `Torrent.date_started`
and `Torrent.date_done` will have local timezone.
Their time is already local time. This just adds `tzinfo`.


close #93  <!-- delete this if it's related to a issue  -->
