### PR TITLE
feat(client)!: `add_torrent` support `pathlib.Path`

### DIFF
--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -25,7 +25,7 @@ options:
       perf: Performance Improvements
       refactor: Code Refactoring
   header:
-    pattern: ^(\w*)(?:\(([\w\$\.\-\*\s]*)\))?\:\s(.*)$
+    pattern: ^(\w*)(?:\(([\w$.\-*\s]*)\))?!?:\s(.*)$
     pattern_maps:
       - Type
       - Scope

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -125,6 +125,12 @@ def test_client_add_base64_raw_data():
     assert _try_read_torrent(b64) == b64, "should skip handle base64 content"
 
 
+def test_client_add_pathlib_path():
+    p = pathlib.Path("tests/fixtures/iso.torrent")
+    b64 = base64.b64encode(p.read_bytes()).decode()
+    assert _try_read_torrent(p) == b64, "should skip handle base64 content"
+
+
 def test_client_add_file_protocol():
     with open("tests/fixtures/iso.torrent", "rb") as f:
         b64 = base64.b64encode(f.read()).decode()

--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -362,7 +362,7 @@ class Client:
 
     def add_torrent(
         self,
-        torrent: Union[BinaryIO, str, bytes],
+        torrent: Union[BinaryIO, str, bytes, pathlib.Path],
         timeout: _Timeout = None,
         *,
         download_dir: str = None,
@@ -382,8 +382,9 @@ class Client:
         - ``http://``, ``https://`` or  ``magnet:`` URL
         - torrent file-like object in binary mode
         - bytes of torrent content
-        - str of base64 encoded torrent file content
-        - ``file://`` URL, deprecated
+        - ``pathlib.Path`` for local torrent file, will be read and encoded as base64.
+        - **deprecated** str of base64 encoded torrent file content
+        - **deprecated** ``file://`` URL
 
         .. NOTE::
 

--- a/transmission_rpc/utils.py
+++ b/transmission_rpc/utils.py
@@ -164,7 +164,7 @@ def _rpc_version_check(method: str, kwargs: Dict[str, Any], rpc_version: int) ->
             )
 
 
-def _try_read_torrent(
+def _try_read_torrent(  # pylint: disable=R0911
     torrent: Union[BinaryIO, str, bytes, pathlib.Path]
 ) -> Optional[str]:
     """


### PR DESCRIPTION
BREAKING CHANGE:
- `Client().add_torrent`: base64 encoded str as torrent is ambiguous and deprecated, will be removed in v4

