### PR TITLE
refactor!: remove unused methods and deprecated function

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,9 +44,6 @@ templates_path = ["_templates"]
 # source_suffix = ['.rst', '.md']
 source_suffix = ".rst"
 
-typehints_use_rtype = False
-napoleon_use_rtype = False
-napoleon_preprocess_types = False
 # The master toctree document.
 master_doc = "index"
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -78,17 +78,6 @@ you should call method like this.
 :code:`{"download-dir": "/path/to/download/dir"}` in arguments.
 
 
-helper
-------------
-
-If you want to know what kwargs you can use for a method,
-you can use :meth:`transmission_rpc.utils.get_arguments`
-to get support arguments.
-For example, transmission 2.94 is rpc version 15,
-so just call :code:`print(get_arguments('torrent-add', 15))`
-
-rpc method and class method are not same, but reversed
-
 you can find rpc version by transmission version from
 `transmission rpc docs <https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#5-protocol-versions>`_
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -151,7 +151,7 @@ def test_real_add_torrent_fd(tr_client: Client):
 
 def test_real_add_torrent_base64(tr_client: Client):
     with open("tests/fixtures/iso.torrent", "rb") as f:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="base64"):
             tr_client.add_torrent(base64.b64encode(f.read()).decode())
     assert len(tr_client.get_torrents()) == 1, "transmission should has at least 1 task"
 
@@ -242,7 +242,7 @@ def test_raise_unauthorized(status_code):
 
 
 def test_ensure_location_str_relative():
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="relative"):
         ensure_location_str(pathlib.Path("."))
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -118,25 +118,10 @@ def test_client_add_magnet():
     assert _try_read_torrent(magnet_url) is None, "handle magnet URL with daemon"
 
 
-def test_client_add_base64_raw_data():
-    with open("tests/fixtures/iso.torrent", "rb") as f:
-        b64 = base64.b64encode(f.read()).decode()
-    with pytest.warns(DeprecationWarning):
-        assert _try_read_torrent(b64) == b64, "should skip handle base64 content"
-
-
 def test_client_add_pathlib_path():
     p = pathlib.Path("tests/fixtures/iso.torrent")
     b64 = base64.b64encode(p.read_bytes()).decode()
     assert _try_read_torrent(p) == b64, "should skip handle base64 content"
-
-
-def test_client_add_file_protocol():
-    with open("tests/fixtures/iso.torrent", "rb") as f:
-        b64 = base64.b64encode(f.read()).decode()
-    p = pathlib.Path("tests/fixtures/iso.torrent").absolute()
-    with pytest.warns(DeprecationWarning):
-        assert _try_read_torrent(f"file://{p}") == b64, "should skip handle base64 content"
 
 
 def test_client_add_read_file_in_base64():

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -227,17 +227,6 @@ def test_real_torrent_start_all(tr_client: Client, fake_hash_factory):
         assert torrent.status == "downloading", "all torrent should be downloading"
 
 
-def test_real_get_files(tr_client: Client):
-    with open("tests/fixtures/iso.torrent", "rb") as f:
-        tr_client.add_torrent(f)
-    assert len(tr_client.get_torrents()) == 1, "transmission should has at least 1 task"
-    for tid, files in tr_client.get_files(1).items():
-        assert files
-        assert isinstance(tid, int)
-        for file in files:
-            assert isinstance(file, File)
-
-
 def test_real_session_get(tr_client: Client):
     tr_client.get_session()
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -151,7 +151,7 @@ def test_real_add_torrent_fd(tr_client: Client):
 
 def test_real_add_torrent_base64(tr_client: Client):
     with open("tests/fixtures/iso.torrent", "rb") as f:
-        with pytest.warns(DeprecationWarning, match="base64"):
+        with pytest.raises(ValueError):
             tr_client.add_torrent(base64.b64encode(f.read()).decode())
     assert len(tr_client.get_torrents()) == 1, "transmission should has at least 1 task"
 
@@ -242,7 +242,7 @@ def test_raise_unauthorized(status_code):
 
 
 def test_ensure_location_str_relative():
-    with pytest.warns(DeprecationWarning, match="absolute"):
+    with pytest.raises(ValueError):
         ensure_location_str(pathlib.Path("."))
 
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -149,13 +149,6 @@ def test_real_add_torrent_fd(tr_client: Client):
     assert len(tr_client.get_torrents()) == 1, "transmission should has at least 1 task"
 
 
-def test_real_add_torrent_base64(tr_client: Client):
-    with open("tests/fixtures/iso.torrent", "rb") as f:
-        with pytest.raises(ValueError, match="base64"):
-            tr_client.add_torrent(base64.b64encode(f.read()).decode())
-    assert len(tr_client.get_torrents()) == 1, "transmission should has at least 1 task"
-
-
 def test_real_add_torrent_http(tr_client: Client):
     tr_client.add_torrent("https://github.com/Trim21/transmission-rpc/raw/master/tests/fixtures/iso.torrent")
     assert len(tr_client.get_torrents()) == 1, "transmission should has at least 1 task"

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,5 @@
-import os
 import time
 import base64
-import os.path
 import pathlib
 from typing import Literal
 from unittest import mock
@@ -155,20 +153,6 @@ def test_real_add_torrent_base64(tr_client: Client):
     with open("tests/fixtures/iso.torrent", "rb") as f:
         with pytest.warns(DeprecationWarning, match="base64"):
             tr_client.add_torrent(base64.b64encode(f.read()).decode())
-    assert len(tr_client.get_torrents()) == 1, "transmission should has at least 1 task"
-
-
-def test_real_add_torrent_file_protocol(tr_client: Client):
-    fs = os.path.abspath(
-        os.path.join(
-            os.path.dirname(
-                __file__,
-            ),
-            "fixtures/iso.torrent",
-        )
-    )
-    with pytest.warns(DeprecationWarning):
-        tr_client.add_torrent("file://" + fs)
     assert len(tr_client.get_torrents()) == 1, "transmission should has at least 1 task"
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,23 +64,3 @@ def test_format_speed(size, expected):
 )
 def test_format_timedelta(delta, expected):
     assert utils.format_timedelta(delta), expected
-
-
-@pytest.mark.parametrize(
-    ("value", "expected"),
-    [
-        (0, 0),
-        (1, 1),
-        (1000, 1),
-        ("true", 1),
-        ("Yes", 1),
-        ("truE", 1),
-        ("baka", 0),
-        ("false", 0),
-        ("no", 0),
-        (True, 1),
-        (False, 0),
-    ],
-)
-def test_rpc_bool(value, expected):
-    assert utils.rpc_bool(value) == expected, f"{value} should be convert to {expected}"

--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -716,11 +716,17 @@ class Client:
         """
         self._rpc_version_warning(15)
         torrent_id = _parse_torrent_id(torrent_id)
+        name = name.strip()  # https://github.com/trim21/transmission-rpc/issues/185
         dirname = os.path.dirname(name)
         if len(dirname) > 0:
             raise ValueError("Target name cannot contain a path delimiter")
-        args = {"path": ensure_location_str(location), "name": name}
-        result = self._request("torrent-rename-path", args, torrent_id, True, timeout=timeout)
+        result = self._request(
+            "torrent-rename-path",
+            {"path": ensure_location_str(location), "name": name},
+            torrent_id,
+            True,
+            timeout=timeout,
+        )
         return result["path"], result["name"]
 
     def queue_top(self, ids: _TorrentIDs, timeout: _Timeout = None) -> None:

--- a/transmission_rpc/error.py
+++ b/transmission_rpc/error.py
@@ -38,7 +38,3 @@ class TransmissionConnectError(TransmissionError, requests.exceptions.Connection
 
 class TransmissionTimeoutError(TransmissionConnectError, requests.exceptions.Timeout):
     """Timeout"""
-
-
-class TransmissionVersionError(TransmissionError):
-    """transmission version is too lower to support some feature"""


### PR DESCRIPTION
remove some deprecated function in v3:
- `Client().add_torrent()`
  - base64 encoded torrent content
  - `file://` protocol
- relative `pathlib.Path` as remove path.
- remove `Client().set_files()`, please call `Client().change_torrent()`
- remove `Client().get_files()`, please call `Client().get_torrents()` and get files from `files` property.