### PR TITLE
Improve hashString documentation in get_torrent()

### DIFF
--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -500,12 +500,12 @@ class Client:
 
         Note
         ----
-        It's recommended that you use torrent's info_hash as torrent id. torrent's info_hash will never change.
+        It's recommended that you use torrent's ``info_hash`` as torrent id. The torrent's ``info_hash`` will never change.
 
         Parameters
         ----------
         torrent_id:
-            torrent id can be an int or a torrent info_hash (hash_string of torrent object).
+            torrent id can be an int or a torrent ``info_hash`` (``hashString`` property of the ``Torrent`` object).
 
         arguments:
             fetched torrent arguments, in most cases you don't need to set this,


### PR DESCRIPTION
Improves Client.get_torrent()'s documentation substituting `hash_string` with `hashString`

See #284