### PR TITLE
Make Status enum format to its str value

### DIFF
--- a/transmission_rpc/torrent.py
+++ b/transmission_rpc/torrent.py
@@ -62,6 +62,9 @@ class Status(str, enum.Enum):
     def seeding(self) -> bool:
         return self == "seeding"
 
+    def __str__(self) -> str:
+        return self.value
+
 
 class FileStat(Container):
     @property


### PR DESCRIPTION
In #294 the status field switched from being a plain str to an enum, which meant it's string representation changed from e.g. 'seeding' to 'Status.SEEDING'. This restores the old behavior.

 <!--
close # 
-->
