### PR TITLE
refactor: drop old enum variable

### DIFF
--- a/transmission_rpc/__init__.py
+++ b/transmission_rpc/__init__.py
@@ -6,24 +6,12 @@ from transmission_rpc.types import File, Group
 from transmission_rpc.client import Client
 from transmission_rpc.session import Session
 from transmission_rpc.torrent import Torrent
-from transmission_rpc.constants import (
-    LOGGER,
-    PRIORITY,
-    RATIO_LIMIT,
-    DEFAULT_TIMEOUT,
-    IdleMode,
-    Priority,
-    IdleLimit,
-    RatioLimit,
-    RatioLimitMode,
-)
+from transmission_rpc.constants import LOGGER, DEFAULT_TIMEOUT, IdleMode, Priority, RatioLimitMode
 
 __all__ = [
     "Client",
     "Group",
     "DEFAULT_TIMEOUT",
-    "PRIORITY",
-    "RATIO_LIMIT",
     "LOGGER",
     "TransmissionError",
     "Session",
@@ -33,8 +21,6 @@ __all__ = [
     "Priority",
     "RatioLimitMode",
     "IdleMode",
-    "RatioLimit",
-    "IdleLimit",
 ]
 
 

--- a/transmission_rpc/constants.py
+++ b/transmission_rpc/constants.py
@@ -9,14 +9,6 @@ LOGGER = logging.getLogger("transmission-rpc")
 LOGGER.setLevel(logging.ERROR)
 
 
-def mirror_dict(source: dict) -> dict:
-    """
-    Creates a dictionary with all values as keys and all keys as values.
-    """
-    source.update({value: key for key, value in source.items()})
-    return source
-
-
 DEFAULT_TIMEOUT = 30.0
 
 
@@ -24,14 +16,6 @@ class Priority(enum.IntEnum):
     Low = -1
     Normal = 0
     High = 1
-
-
-# TODO: remove this in 5.0
-TR_PRI_LOW = Priority.Low
-TR_PRI_NORMAL = Priority.Normal
-TR_PRI_HIGH = Priority.High
-
-PRIORITY = mirror_dict({"low": TR_PRI_LOW, "normal": TR_PRI_NORMAL, "high": TR_PRI_HIGH})
 
 
 class RatioLimitMode(enum.IntEnum):
@@ -45,24 +29,6 @@ class RatioLimitMode(enum.IntEnum):
     Unlimited = 2
 
 
-# TODO: remove this in 5.0
-TR_RATIOLIMIT_GLOBAL = RatioLimitMode.Global  # follow the global settings
-TR_RATIOLIMIT_SINGLE = RatioLimitMode.Single  # override the global settings, seeding until a certain ratio
-TR_RATIOLIMIT_UNLIMITED = RatioLimitMode.Unlimited  # override the global settings, seeding regardless of ratio
-
-# TODO: remove these in 5.0
-RatioLimit = RatioLimitMode
-
-# TODO: remove these in 5.0
-RATIO_LIMIT = mirror_dict(
-    {
-        "global": TR_RATIOLIMIT_GLOBAL,
-        "single": TR_RATIOLIMIT_SINGLE,
-        "unlimited": TR_RATIOLIMIT_UNLIMITED,
-    }
-)
-
-
 class IdleMode(enum.IntEnum):
     """torrent idle mode"""
 
@@ -72,21 +38,6 @@ class IdleMode(enum.IntEnum):
     Single = 1
     #: override the global settings, seeding regardless of activity
     Unlimited = 2
-
-
-# TODO: remove these in 5.0
-IdleLimit = IdleMode
-TR_IDLELIMIT_GLOBAL = IdleMode.Global  # follow the global settings
-TR_IDLELIMIT_SINGLE = IdleMode.Single  # override the global settings, seeding until a certain idle time
-TR_IDLELIMIT_UNLIMITED = IdleMode.Unlimited  # override the global settings, seeding regardless of activity
-
-IDLE_LIMIT = mirror_dict(
-    {
-        "global": TR_RATIOLIMIT_GLOBAL,
-        "single": TR_RATIOLIMIT_SINGLE,
-        "unlimited": TR_RATIOLIMIT_UNLIMITED,
-    }
-)
 
 
 class Args(NamedTuple):

--- a/transmission_rpc/torrent.py
+++ b/transmission_rpc/torrent.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone, timedelta
 
 from transmission_rpc.types import File, Container
 from transmission_rpc.utils import format_timedelta
-from transmission_rpc.constants import PRIORITY, IDLE_LIMIT, RATIO_LIMIT, Priority
+from transmission_rpc.constants import IdleMode, Priority, RatioLimitMode
 
 _STATUS_NEW_MAPPING = {
     0: "stopped",
@@ -396,7 +396,7 @@ class Torrent(Container):
             result.extend(
                 File(
                     selected=bool(raw_selected),
-                    priority=PRIORITY[raw_priority],
+                    priority=Priority(raw_priority),
                     size=file["length"],
                     name=file["name"],
                     completed=file["bytesCompleted"],
@@ -810,16 +810,16 @@ class Torrent(Container):
     #     return None
 
     @property
-    def priority(self) -> str:
+    def priority(self) -> Priority:
         """
         Bandwidth priority as string.
         Can be one of 'low', 'normal', 'high'. This is a mutator.
         """
 
-        return PRIORITY[self.fields["bandwidthPriority"]]
+        return Priority(self.fields["bandwidthPriority"])
 
     @property
-    def seed_idle_mode(self) -> str:
+    def seed_idle_mode(self) -> IdleMode:
         """
         Seed idle mode as string. Can be one of 'global', 'single' or 'unlimited'.
 
@@ -827,7 +827,7 @@ class Torrent(Container):
          * single, use torrent seed idle limit. See seed_idle_limit.
          * unlimited, no seed idle limit.
         """
-        return IDLE_LIMIT[self.fields["seedIdleMode"]]
+        return IdleMode(self.fields["seedIdleMode"])
 
     @property
     def seed_ratio_limit(self) -> float:
@@ -839,7 +839,7 @@ class Torrent(Container):
         return float(self.fields["seedRatioLimit"])
 
     @property
-    def seed_ratio_mode(self) -> str:
+    def seed_ratio_mode(self) -> RatioLimitMode:
         """
         Seed ratio mode as string. Can be one of 'global', 'single' or 'unlimited'.
 
@@ -847,7 +847,7 @@ class Torrent(Container):
          * single, use torrent seed ratio limit. See seed_ratio_limit.
          * unlimited, no seed ratio limit.
         """
-        return RATIO_LIMIT[self.fields["seedRatioMode"]]
+        return RatioLimitMode(self.fields["seedRatioMode"])
 
     def __repr__(self) -> str:
         return f'<Torrent {self.id} "{self.name}">'

--- a/transmission_rpc/types.py
+++ b/transmission_rpc/types.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Tuple, Union, TypeVar, Optional, NamedTuple
 
-from transmission_rpc import Priority
+from transmission_rpc.constants import Priority
 
 _Number = Union[int, float]
 _Timeout = Optional[Union[_Number, Tuple[_Number, _Number]]]

--- a/transmission_rpc/types.py
+++ b/transmission_rpc/types.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, Tuple, Union, TypeVar, Optional, NamedTuple
 
-from typing_extensions import Literal
+from transmission_rpc import Priority
 
 _Number = Union[int, float]
 _Timeout = Optional[Union[_Number, Tuple[_Number, _Number]]]
@@ -23,7 +23,7 @@ class File(NamedTuple):
     name: str  # file name
     size: int  # file size in bytes
     completed: int  # bytes completed
-    priority: Literal["high", "normal", "low"]
+    priority: Priority
     selected: bool  # if selected for download
     id: int  # id of the file of this torrent, not should not be used outside the torrent scope.
 


### PR DESCRIPTION
## Breaking Changes:

1. remove `PRIORITY`, `RATIO_LIMIT` `RatioLimit` and `IdleLimit`, use `Priority`, `RatioLimitMode` and `IdleMode` instead.
2. `File.priority` are now enum `Priority` instead of string.
3. `Torrent.priority` are now enum `Priority` instead of string.
4. `Torrent.seed_idle_mode` are now enum `IdleMode` instead of string.
5. `Torrent.seed_ratio_mode` are now enum `RatioLimitMode` instead of string.

