### PR TITLE
refactor: remove deprecated methods and properties

### DIFF
--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -4,7 +4,6 @@ import types
 import string
 import logging
 import pathlib
-import warnings
 import urllib.parse
 from typing import Any, Dict, List, Type, Tuple, Union, TypeVar, BinaryIO, Iterable, Optional
 from urllib.parse import quote
@@ -746,35 +745,6 @@ class Client:
         """
         args = {"location": ensure_location_str(location), "move": bool(move)}
         self._request(RpcMethod.TorrentSetLocation, args, ids, True, timeout=timeout)
-
-    def locate_torrent_data(
-        self,
-        ids: _TorrentIDs,
-        location: Union[str, pathlib.Path],
-        timeout: Optional[_Timeout] = None,
-    ) -> None:
-        """
-        Locate torrent data at the provided location.
-
-        Warnings
-        --------
-            since transmission-rpc version 4.2.1, this method is deprecated.
-
-            Use ``client.move_torrent_data(ids, location, move=False)`` instead
-
-        this is same rpc call as :py:meth:`Client.move_torrent_data`, but with arguments ``move=False``
-
-        See Also
-        --------
-
-        `RPC Spec: moving-a-torrent <https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#36-moving-a-torrent>`_
-        """
-        warnings.warn(
-            "locate_torrent_data is deprecated since version 4.2.1, please use `move_torrent_data` with 'move=False'",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.move_torrent_data(ids=ids, location=location, timeout=timeout, move=False)
 
     def rename_torrent_path(
         self,

--- a/transmission_rpc/session.py
+++ b/transmission_rpc/session.py
@@ -1,4 +1,3 @@
-import warnings
 from typing import List, Optional
 
 from typing_extensions import Literal
@@ -307,21 +306,9 @@ class Session(Container):
         return self.fields["seed-queue-size"]
 
     @property
-    def seedRatioLimit(self) -> float:
-        """the default seed ratio for torrents to use"""
-        warnings.warn("use .seed_ratio_limit", DeprecationWarning, stacklevel=2)
-        return self.fields["seedRatioLimit"]
-
-    @property
     def seed_ratio_limit(self) -> float:
         """the default seed ratio for torrents to use"""
         return self.fields["seedRatioLimit"]
-
-    @property
-    def seedRatioLimited(self) -> bool:
-        """true if seedRatioLimit is honored by default"""
-        warnings.warn("use .seed_ratio_limited", DeprecationWarning, stacklevel=2)
-        return self.fields["seedRatioLimited"]
 
     @property
     def seed_ratio_limited(self) -> bool:

--- a/transmission_rpc/torrent.py
+++ b/transmission_rpc/torrent.py
@@ -1,5 +1,4 @@
 import enum
-import warnings
 from typing import Any, Dict, List, Optional
 from datetime import datetime, timezone, timedelta
 
@@ -362,10 +361,6 @@ class Torrent(Container):
     @property
     def file_count(self) -> Optional[int]:
         return self.fields["file-count"]
-
-    def files(self) -> List[File]:
-        warnings.warn(DeprecationWarning("'.files()' is deprecated, please use '.get_files()'"), stacklevel=2)
-        return self.get_files()
 
     def get_files(self) -> List[File]:
         """
@@ -743,26 +738,9 @@ class Torrent(Container):
         return datetime.fromtimestamp(self.fields["activityDate"], timezone.utc)
 
     @property
-    def date_active(self) -> datetime:
-        warnings.warn("use .activity_date", DeprecationWarning, stacklevel=2)
-        return self.activity_date
-
-    @property
-    def date_added(self) -> datetime:
-        """raw field ``addedDate`` as ``datetime.datetime`` in **utc timezone**."""
-        warnings.warn("use .added_date", DeprecationWarning, stacklevel=2)
-        return self.added_date
-
-    @property
     def added_date(self) -> datetime:
         """When the torrent was first added."""
         return datetime.fromtimestamp(self.fields["addedDate"], timezone.utc)
-
-    @property
-    def date_started(self) -> datetime:
-        """raw field ``startDate`` as ``datetime.datetime`` in **utc timezone**."""
-        warnings.warn("use .start_date", DeprecationWarning, stacklevel=2)
-        return self.start_date
 
     @property
     def start_date(self) -> datetime:
@@ -778,11 +756,6 @@ class Torrent(Container):
         if done_date == 0:
             return None
         return datetime.fromtimestamp(done_date).astimezone()
-
-    @property
-    def date_done(self) -> Optional[datetime]:
-        warnings.warn("use .done_date", DeprecationWarning, stacklevel=2)
-        return self.done_date
 
     def format_eta(self) -> str:
         """


### PR DESCRIPTION
BREAKING CHANGES:
remove deprecated methods and properties
- `client.locate_torrent_data`
- `torrent.seedRatioLimit`, use `.seed_ratio_limit` instead.
- `torrent.seedRatioLimited`, use `.seed_ratio_limited` instead.
-  `torrent.files`, use `torrent.get_files()` instead.
- `torrent.date_active`, use `torrent.activity_date` instread.
- `torrent.date_added`, use `torrent.added_date` instread.
- `torrent.date_started`, use `torrent.start_date` instread.
- `torrent.date_done`, use `torrent.done_date` instread.
