### PR TITLE
feat(client): add URL parameter and support for Unix sockets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
 
 dependencies = [
     'requests~=2.23',
+    'requests-unixsocket2~=0.4.0',
     'typing-extensions>=4.5.0',
 ]
 


### PR DESCRIPTION
This commit makes it possible to pass the full URL to Client() in one go, and also enables support for connecting to a Transmission daemon that listens on a Unix socket instead of an IP:port.