### PR TITLE
fix(torrent): `get_files()` should throw `KeyError` if `files` not fetched

### DIFF
--- a/tests/test_torrent.py
+++ b/tests/test_torrent.py
@@ -45,7 +45,8 @@ def test_attributes():
 
     with pytest.raises(KeyError):
         torrent.format_eta()
-    assert not torrent.get_files()
+    with pytest.raises(KeyError):
+        torrent.get_files()
 
     data = {
         "id": 1,

--- a/transmission_rpc/torrent.py
+++ b/transmission_rpc/torrent.py
@@ -429,25 +429,25 @@ class Torrent(Container):
                 print(file.id)
 
         """
-        result: list[File] = []
-        if "files" in self.fields:
-            files = self.fields["files"]
-            indices = range(len(files))
-            priorities = self.fields["priorities"]
-            wanted = self.fields["wanted"]
-            result.extend(
-                File(
-                    selected=bool(raw_selected),
-                    priority=Priority(raw_priority),
-                    size=file["length"],
-                    name=file["name"],
-                    completed=file["bytesCompleted"],
-                    id=id,
-                )
-                for id, file, raw_priority, raw_selected in zip(indices, files, priorities, wanted)
+        files = self.fields["files"]
+        indices = range(len(files))
+        priorities: list[Priority | None] = (
+            [Priority(v) for v in self.fields["priorities"]] if "priorities" in self.fields else [None] * len(files)
+        )
+        wanted: list[bool | None] = (
+            [bool(v) for v in self.fields["wanted"]] if "wanted" in self.fields else [None] * len(files)
+        )
+        return [
+            File(
+                selected=selected,
+                priority=priority,
+                size=file["length"],
+                name=file["name"],
+                completed=file["bytesCompleted"],
+                id=id,
             )
-
-        return result
+            for id, file, priority, selected in zip(indices, files, priorities, wanted)
+        ]
 
     @property
     def file_stats(self) -> list[FileStat]:

--- a/transmission_rpc/types.py
+++ b/transmission_rpc/types.py
@@ -30,10 +30,10 @@ class File(NamedTuple):
     completed: int
     """bytes completed"""
 
-    priority: Priority
+    priority: Priority | None
     """download priority"""
 
-    selected: bool
+    selected: bool | None
     """if selected for download"""
 
     id: int


### PR DESCRIPTION
BREAKING CHANGE: `torrent.get_files()` will raise a KeyError if field `files` not fetched. `file.priority` and `file.selected` are not optional, based on fields fetched.