### PR TITLE
feat(client): Add support for Unix sockets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,6 +53,33 @@ jobs:
           flags: "${{ matrix.python }}"
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-unix-socket:
+    # At the time of writing ubuntu-latest is ubuntu-22.04. But we need
+    # an even later version because ubuntu-22.04 provides Transmission 3.0.0 but
+    # Unix socket support was added in Transmission 4.0.0. Use 24.04 which is
+    # currently in beta.
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - run: sudo apt-get install -y transmission-daemon
+      - run: mkdir -p $HOME/Downloads
+      - run: transmission-daemon --rpc-bind-address unix:/tmp/transmission.socket
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9  # Oldest version available for ubuntu-24.04
+          cache: pip
+      - run: pip install -e .[dev]
+      - run: coverage run -m pytest
+        env:
+          TR_PROTOCOL: 'http+unix'
+          TR_HOST: '/tmp/transmission.socket'
+      - uses: codecov/codecov-action@v4
+        with:
+          flags: "unix-socket"
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   dist-files:
     runs-on: ubuntu-22.04
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -212,7 +212,7 @@ def test_real_torrent_get_files(tr_client: Client):
 )
 def test_raise_unauthorized(status_code):
     m = mock.Mock(return_value=mock.Mock(status=status_code))
-    with mock.patch("urllib3.PoolManager.request", m), pytest.raises(TransmissionAuthError):
+    with mock.patch("urllib3.HTTPConnectionPool.request", m), pytest.raises(TransmissionAuthError):
         Client()
 
 

--- a/transmission_rpc/_unix_socket.py
+++ b/transmission_rpc/_unix_socket.py
@@ -1,0 +1,53 @@
+# Inspired from:
+#   https://github.com/getsentry/sentry/blob/9d03adef66f63e29a5d95189447d02ba0b68c2af/src/sentry/net/http.py#L215-L244
+# See also:
+#   https://github.com/urllib3/urllib3/issues/1465
+
+from __future__ import annotations
+
+import socket
+from typing import Any
+
+from urllib3.connection import HTTPConnection
+from urllib3.connectionpool import HTTPConnectionPool
+from urllib3.util.connection import _TYPE_SOCKET_OPTIONS
+from urllib3.util.timeout import _DEFAULT_TIMEOUT
+
+
+class UnixHTTPConnection(HTTPConnection):
+    def __init__(
+        self,
+        host: str,
+        *,
+        # The default socket options include `TCP_NODELAY` which won't work here.
+        socket_options: None | _TYPE_SOCKET_OPTIONS = None,
+        **kwargs: Any,
+    ):
+        self.socket_path = host
+        # We're using the `host` as the socket path, but
+        # urllib3 uses this host as the Host header by default.
+        # If we send along the socket path as a Host header, this is
+        # never what you want and would typically be malformed value.
+        # So we fake this by sending along `localhost` by default as
+        # other libraries do.
+        super().__init__(host="localhost", socket_options=socket_options, **kwargs)
+
+    def _new_conn(self) -> socket.socket:
+        sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+
+        socket_options = self.socket_options
+        if socket_options is not None:
+            for opt in socket_options:
+                sock.setsockopt(*opt)
+
+        if self.timeout is not _DEFAULT_TIMEOUT:  # type: ignore
+            sock.settimeout(self.timeout)
+        sock.connect(self.socket_path)
+        return sock
+
+
+class UnixHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = UnixHTTPConnection
+
+    def __str__(self) -> str:
+        return f"{type(self).__name__}(host={self.host})"


### PR DESCRIPTION
This commit adds support for the `http+unix` protocol which makes it possible to specify a Unix socket path as the host. This in turn makes it possible to connect to Transmission daemons that listen on a Unix socket file as opposed to an IP:port.

This is an alternative to #445.