### PR TITLE
ci: Run CI on every branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,11 +2,7 @@ name: test
 
 on:
   push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   test:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -2,11 +2,7 @@ name: CodeQL
 
 on:
   push:
-    branches: [master]
-
   pull_request:
-    branches: [master]
-
   schedule:
     - cron: 0 3 * * 5
 

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,11 +2,7 @@ name: lint
 
 on:
   push:
-    branches:
-      - master
   pull_request:
-    branches:
-      - master
 
 jobs:
   mypy:


### PR DESCRIPTION
Only running CI on master makes it harder to check the results without opening a PR.