### PR TITLE
fix(client): improve error handling of empty torrent metadata

### DIFF
--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -456,7 +456,7 @@ class Client:
             kwargs["filename"] = torrent
         else:
             if not torrent_data:
-                raise RuntimeError("Torrent metadata is empty")
+                raise ValueError("Torrent metadata is empty")
             kwargs["metainfo"] = torrent_data
 
         return next(iter(self._request(RpcMethod.TorrentAdd, kwargs, timeout=timeout).values()))

--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -452,10 +452,12 @@ class Client:
         )
 
         torrent_data = _try_read_torrent(torrent)
-        if torrent_data:
-            kwargs["metainfo"] = torrent_data
-        else:
+        if torrent_data is None:
             kwargs["filename"] = torrent
+        else:
+            if not torrent_data:
+                raise RuntimeError("Torrent metadata is empty")
+            kwargs["metainfo"] = torrent_data
 
         return next(iter(self._request(RpcMethod.TorrentAdd, kwargs, timeout=timeout).values()))
 


### PR DESCRIPTION
If an empty torrent file (as in, zero bytes) is passed to `add_torrent()`, the previous code would fall over and attempt to awkwardly pass the path itself as the torrent data, resulting in a very cryptic error being raised. This commit ensures we fail early and cleanly in this case.