### PR TITLE
Fix consistency with double [float] number type parsing

### DIFF
--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -171,7 +171,7 @@ class Client:
                 raise ValueError("timeout tuple can only include 2 numbers elements")
             for v in value:
                 if not isinstance(v, (float, int)):
-                    raise TypeError("element of timeout tuple can only be int of float")
+                    raise TypeError("element of timeout tuple can only be int or float")
             self._query_timeout = (value[0], value[1])  # for type checker
         elif value is None:
             self._query_timeout = DEFAULT_TIMEOUT
@@ -858,7 +858,7 @@ class Client:
         script_torrent_done_filename: str | None = None,
         seed_queue_enabled: bool | None = None,
         seed_queue_size: int | None = None,
-        seed_ratio_limit: int | None = None,
+        seed_ratio_limit: float | None = None,
         seed_ratio_limited: bool | None = None,
         speed_limit_down: int | None = None,
         speed_limit_down_enabled: bool | None = None,

--- a/transmission_rpc/constants.py
+++ b/transmission_rpc/constants.py
@@ -125,7 +125,7 @@ TORRENT_GET_ARGS: dict[str, Args] = {
     "magnetLink": Args(Type.string, 7, None, None, None, "The magnet link for this torrent."),
     "manualAnnounceTime": Args(Type.number, 1, description="The time until you manually ask for more peers."),
     "maxConnectedPeers": Args(Type.number, 1, None, None, None, "Maximum of connected peers."),
-    "metadataPercentComplete": Args(Type.number, 7, description="Download progress of metadata. 0.0 to 1.0."),
+    "metadataPercentComplete": Args(Type.double, 7, description="Download progress of metadata. 0.0 to 1.0."),
     "name": Args(Type.string, 1, None, None, None, "Torrent name."),
     "peer-limit": Args(Type.number, 5, None, None, None, "Maximum number of peers."),
     "peers": Args(Type.array, 2, None, None, None, "Array of peer objects."),

--- a/transmission_rpc/session.py
+++ b/transmission_rpc/session.py
@@ -307,7 +307,7 @@ class Session(Container):
     @property
     def seed_ratio_limit(self) -> float:
         """the default seed ratio for torrents to use"""
-        return self.fields["seedRatioLimit"]
+        return float(self.fields["seedRatioLimit"])
 
     @property
     def seed_ratio_limited(self) -> bool:

--- a/transmission_rpc/torrent.py
+++ b/transmission_rpc/torrent.py
@@ -293,7 +293,7 @@ class Torrent(Container):
         bytes_all = self.total_size
         bytes_done = sum(x["bytesCompleted"] for x in self.fields["fileStats"])
         bytes_avail = self.desired_available + bytes_done
-        return (bytes_avail / bytes_all) * 100 if bytes_all else 0
+        return float((bytes_avail / bytes_all) * 100 if bytes_all else 0)
 
     # @property
     # def availability(self) -> list:
@@ -521,7 +521,7 @@ class Torrent(Container):
         For magnet links, this number will from from 0 to 1 as the metadata is downloaded.
         Range is [0..1]
         """
-        return self.fields["metadataPercentComplete"]
+        return float(self.fields["metadataPercentComplete"])
 
     @property
     def peer_limit(self) -> int:
@@ -556,7 +556,7 @@ class Torrent(Container):
     @property
     def percent_complete(self) -> float:
         """How much has been downloaded of the entire torrent. Range is [0..1]"""
-        return self.fields["percentComplete"]
+        return float(self.fields["percentComplete"])
 
     @property
     def percent_done(self) -> float:
@@ -565,7 +565,7 @@ class Torrent(Container):
         from percentComplete if the user wants only some of the torrent's files.
         Range is [0..1]
         """
-        return self.fields["percentDone"]
+        return float(self.fields["percentDone"])
 
     @property
     def pieces(self) -> str:
@@ -611,7 +611,7 @@ class Torrent(Container):
 
     @property
     def recheck_progress(self) -> float:
-        return self.fields["recheckProgress"]
+        return float(self.fields["recheckProgress"])
 
     @property
     def seconds_downloading(self) -> int:
@@ -678,7 +678,7 @@ class Torrent(Container):
 
     @property
     def upload_ratio(self) -> float:
-        return self.fields["uploadRatio"]
+        return float(self.fields["uploadRatio"])
 
     @property
     def wanted(self) -> list[int]:


### PR DESCRIPTION
# Description

Fixes #456

This PR fixes 'double' number type parsing, by ensuring that all values documented/intended as 'doubles' in the transmission RPC are returned as 'float's by this library (as they're already currently correctly documented).

This fixes the issue of unintentionally returning 'int' types for these functions which document 'float' return types when the return value is a whole number (particularly `0` or `1`). Some functions in the library already did this, but not all of them, so this PR fixes this inconsistency.

See the upstream transmission documentation for all parameters which are a 'double' value type which should be returned as 'float's by this library: https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md

## Testing

I ran all tests (`task lint` and `task test` [note, an `__init__.py` file needed to be added to the `tests/` directory for `task test` to work]) as well as did a basic sanity check against live usage of this package after these changes.

Before these changes:
```
type(client.get_torrents()[0].percent_done)
<class 'int'>
```

After these changes:
```
type(client.get_torrents()[0].percent_done)
<class 'float'>
```