### PR TITLE
fix(log): Expensive DEBUG log always run (#470)

### DIFF
--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -275,7 +275,9 @@ class Client:
                 "failed to parse response as json", method=method, argument=arguments, rawResponse=http_data
             ) from error
 
-        self.logger.debug(json.dumps(data, indent=2))
+        if self.logger.isEnabledFor(logging.DEBUG):
+            self.logger.debug(json.dumps(data, indent=2))
+
         if "result" not in data:
             raise TransmissionError(
                 "Query failed, response data missing without result.",


### PR DESCRIPTION
Don't run expensive JSON serialization for `DEBUG` logging unless that level would be printed/emitted.

Fixes #470
