### PR TITLE
feat(client): support http+unix URLs

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -106,6 +106,14 @@ def test_format_timedelta(delta, expected):
             "port": 443,
             "path": "/",
         },
+        "http+unix://%2Fvar%2Frun%2Ftransmission.sock/transmission/rpc": {
+            "protocol": "http+unix",
+            "username": None,
+            "password": None,
+            "host": "/var/run/transmission.sock",
+            "port": None,
+            "path": "/transmission/rpc",
+        },
     }.items(),
 )
 def test_from_url(url: str, kwargs: dict[str, Any]):

--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -143,7 +143,7 @@ class Client:
             path = "/transmission/rpc"
 
         url_host = "localhost" if protocol == "http+unix" else host
-        url = f"{protocol}://{url_host}:{port}{path}"
+        url = f"{protocol}://{url_host}{'' if port is None else f':{port}'}{path}"
         self._url = str(url)
         self._path = path
 

--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -101,7 +101,7 @@ class Client:
         username: str | None = None,
         password: str | None = None,
         host: str = "127.0.0.1",
-        port: int = 9091,
+        port: int | None = 9091,
         path: str = "/transmission/rpc",
         timeout: float | Timeout | None = DEFAULT_TIMEOUT,
         logger: logging.Logger = LOGGER,


### PR DESCRIPTION
This adds support for Unix socket URLs as a follow-up to Unix socket connection support in #447.

There is no standard for Unix socket URLs, see whatwg/url#577. This PR tries to be consistent with prior art in https://github.com/msabramo/requests-unixsocket.