### PR TITLE
docs: fix markup error in Session docstring

### DIFF
--- a/transmission_rpc/session.py
+++ b/transmission_rpc/session.py
@@ -112,7 +112,7 @@ class Session(Container):
     https://github.com/transmission/transmission/blob/main/docs/rpc-spec.md#41-session-arguments
 
     Warnings:
-        setter on session's properties has been removed, please use :py:meth`Client.set_session` instead
+        setter on session's properties has been removed, please use :py:meth:`Client.set_session` instead
     """
 
     @property


### PR DESCRIPTION
While looking at https://transmission-rpc.readthedocs.io/en/v7.0.11/session.html I noticed some broken raw markup:

![paveikslas](https://github.com/user-attachments/assets/d4b0f03a-1216-40a1-a593-e22805e6c75f)

I hope this will fix it.