### PR TITLE
fix(client)!: avoid querying all torrents in start_all

### DIFF
--- a/tests/unit/client/test_rpc_methods.py
+++ b/tests/unit/client/test_rpc_methods.py
@@ -8,23 +8,27 @@ from transmission_rpc.client import Client
 from transmission_rpc.torrent import Torrent
 
 
-def test_start_all_bypass_queue(mock_network: Any, success_response: Any) -> None:
-    """
-    Verify that `start_all(bypass_queue=True)` correctly calls `torrent-start-now`
-    after fetching the list of torrents.
-    """
+@pytest.mark.parametrize(
+    ("bypass_queue", "expected_method"),
+    [(False, "torrent-start"), (True, "torrent-start-now")],
+)
+def test_start_all_uses_single_action_request(
+    mock_network: Any,
+    success_response: Any,
+    bypass_queue: bool,
+    expected_method: str,
+) -> None:
+    """Verify that start_all delegates the all-torrent action directly to Transmission."""
     mock_network.side_effect = [
         success_response(),  # init
-        success_response({"torrents": [{"id": 1, "queuePosition": 1, "hashString": "a"}]}),  # get_torrents
         success_response(),  # start
     ]
     c = Client()
-    c.start_all(bypass_queue=True)
+    assert c.start_all(bypass_queue=bypass_queue) is None
 
-    # Verify the last call was torrent-start-now
-    assert mock_network.call_count == 3
+    assert mock_network.call_count == 2
     last_call_json = mock_network.call_args_list[-1][1]["json"]
-    assert last_call_json["method"] == "torrent-start-now"
+    assert last_call_json == {"method": expected_method, "arguments": {}}
 
 
 def test_get_torrent_with_args(mock_network: Any, success_response: Any) -> None:
@@ -271,9 +275,7 @@ def test_passthrough_rpc_commands(mock_network: Any, success_response: Any) -> N
     """Verify execution of client command methods."""
     mock_network.side_effect = [
         success_response(),  # init
-        # return a valid torrent for start_all to operate on
-        success_response({"torrents": [{"id": 1, "queuePosition": 0, "hashString": "h"}]}),  # start_all (get)
-        success_response(),  # start_all (start)
+        success_response(),  # start_all
         success_response({"blocklist-size": 10}),  # blocklist
     ]
     c = Client()

--- a/tests/unit/client/test_rpc_methods.py
+++ b/tests/unit/client/test_rpc_methods.py
@@ -8,15 +8,9 @@ from transmission_rpc.client import Client
 from transmission_rpc.torrent import Torrent
 
 
-@pytest.mark.parametrize(
-    ("bypass_queue", "expected_method"),
-    [(False, "torrent-start"), (True, "torrent-start-now")],
-)
 def test_start_all_uses_single_action_request(
     mock_network: Any,
     success_response: Any,
-    bypass_queue: bool,
-    expected_method: str,
 ) -> None:
     """Verify that start_all delegates the all-torrent action directly to Transmission."""
     mock_network.side_effect = [
@@ -24,11 +18,11 @@ def test_start_all_uses_single_action_request(
         success_response(),  # start
     ]
     c = Client()
-    assert c.start_all(bypass_queue=bypass_queue) is None
+    assert c.start_all() is None
 
     assert mock_network.call_count == 2
     last_call_json = mock_network.call_args_list[-1][1]["json"]
-    assert last_call_json == {"method": expected_method, "arguments": {}}
+    assert last_call_json == {"method": "torrent-start", "arguments": {}}
 
 
 def test_get_torrent_with_args(mock_network: Any, success_response: Any) -> None:
@@ -280,8 +274,8 @@ def test_passthrough_rpc_commands(mock_network: Any, success_response: Any) -> N
     ]
     c = Client()
 
-    # start_all bypass_queue
-    c.start_all(bypass_queue=True)
+    # start_all
+    c.start_all()
 
     # blocklist_update
     assert c.blocklist_update() == 10

--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -525,12 +525,9 @@ class Client:
             method = RpcMethod.TorrentStartNow
         self._request(method, {}, ids, True, timeout=timeout)
 
-    def start_all(self, bypass_queue: bool = False, timeout: _Timeout | None = None) -> None:
+    def start_all(self, timeout: _Timeout | None = None) -> None:
         """Start all torrents respecting the queue order"""
-        method = RpcMethod.TorrentStart
-        if bypass_queue:
-            method = RpcMethod.TorrentStartNow
-        self._request(method, timeout=timeout)
+        self._request(RpcMethod.TorrentStart, timeout=timeout)
 
     def stop_torrent(self, ids: _TorrentIDs, timeout: _Timeout | None = None) -> None:
         """stop torrent(s) with provided id(s)"""

--- a/transmission_rpc/client.py
+++ b/transmission_rpc/client.py
@@ -530,14 +530,7 @@ class Client:
         method = RpcMethod.TorrentStart
         if bypass_queue:
             method = RpcMethod.TorrentStartNow
-        torrent_list = sorted(self.get_torrents(), key=lambda t: t.queue_position)
-        self._request(
-            method,
-            {},
-            ids=[x.id for x in torrent_list],
-            require_ids=True,
-            timeout=timeout,
-        )
+        self._request(method, timeout=timeout)
 
     def stop_torrent(self, ids: _TorrentIDs, timeout: _Timeout | None = None) -> None:
         """stop torrent(s) with provided id(s)"""


### PR DESCRIPTION
## Summary

`Client.start_all()` currently fetches all torrents before sending a separate start request, and raises `ValueError` when no torrents exist.

Send one `torrent-start` request without IDs, which Transmission applies to all torrents. Remove the client-only `bypass_queue` option so `start_all()` consistently respects queue order.

## Compatibility

`Client.start_all()` no longer accepts `bypass_queue`. `Client.start_torrent()` is unchanged.

## Testing

- `coverage run -m pytest` — 158 passed against Transmission 4.1.0-beta.2
- `coverage report` — 100%
- `mypy --show-column-numbers transmission_rpc` — passed
- `pre-commit run --all-files --show-diff-on-failure` — passed
